### PR TITLE
refactor: simplify keyboard module architecture

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -34,7 +34,7 @@ unfocused_border_color = 0x808080 # Gray color for unfocused windows (hex format
 # Available modifiers:
 #   Primary: Super, Alt, Ctrl, Shift
 #   Alternative names: Win/Windows/Cmd (for Super), Meta (for Alt), Control/Ctl (for Ctrl)
-#   Less common: Mod2/NumLock, Mod3/ScrollLock, Mod5/AltGr
+#   Less common: Mod2/NumLock, Mod3/ScrollLock, Mod5
 #   Special: Hyper (combines Super+Alt+Ctrl+Shift)
 #
 # You can combine multiple modifiers like "Ctrl+Alt+t" or "Super+Shift+Alt+F12"

--- a/docs/IMPLEMENTATION_DETAILS.md
+++ b/docs/IMPLEMENTATION_DETAILS.md
@@ -332,8 +332,9 @@ The same physical key produces different keysyms based on modifiers!
 
 ```rust
 // From src/keyboard.rs
-pub struct KeyboardManager {
-    keycode_to_keysym: HashMap<Keycode, Vec<Keysym>>,
+pub struct ShortcutManager {
+    keyname_to_keysym: HashMap<String, u32>,
+    keysym_to_keycode: HashMap<u32, u8>,
     shortcuts: Vec<Shortcut>,
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,7 +35,7 @@ Rustile currently provides:
   - [ ] **Application rules** - Automatically float specific applications (dialogs, popups)
 
 - **Keyboard Improvements**
-  - [ ] ⭐ **Better modifier handling** - Distinguish between Alt/AltGr (fix Xephyr issues?)
+  - [ ] ⭐ **Better modifier handling** - Distinguish between left and right Alt keys
   - [ ] **Key management simplification** - Consider using xmodmap for cleaner key handling
   - [ ] **Shortcut conflicts detection** - Warn about conflicting keybindings
 

--- a/docs/adr/003-srp-refactoring-three-module-architecture.md
+++ b/docs/adr/003-srp-refactoring-three-module-architecture.md
@@ -36,7 +36,7 @@ pub struct WindowRenderer {
 ```rust
 pub struct WindowManager<C: Connection> {
     conn: C,
-    keyboard_manager: KeyboardManager,
+    shortcut_manager: ShortcutManager,
     window_state: WindowState,
     window_renderer: WindowRenderer,
 }

--- a/docs/adr/004-x11-event-registration-strategy.md
+++ b/docs/adr/004-x11-event-registration-strategy.md
@@ -23,9 +23,9 @@ conn.change_window_attributes(root, &ChangeWindowAttributesAux::new().event_mask
 ```
 
 ### Layer 2: Keyboard Events (Per-Shortcut Registration)
-Register specific key combinations through KeyboardManager:
+Register specific key combinations through ShortcutManager:
 ```rust
-keyboard_manager.register_shortcuts(&conn, root, config.shortcuts())?;
+shortcut_manager.register_shortcuts(&conn, root, config.shortcuts())?;
 ```
 
 ### Layer 3: Focus Events (Automatic via Window Operations)

--- a/docs/adr/007-x11-keyboard-mapping-understanding.md
+++ b/docs/adr/007-x11-keyboard-mapping-understanding.md
@@ -51,7 +51,7 @@ These numbers are defined in X11 standards:
 // Position meanings:
 // [0]: No modifiers
 // [1]: Shift
-// [2]: Mode_switch/AltGr (or same as [0] on US keyboards)
+// [2]: Mode_switch/ISO_Level3_Shift (or same as [0] on US keyboards)
 // [3]: Shift+Mode_switch (or same as [1] on US keyboards)
 ```
 

--- a/docs/adr/008-x11-modifier-system-and-shortcuts.md
+++ b/docs/adr/008-x11-modifier-system-and-shortcuts.md
@@ -28,7 +28,7 @@ ModMask::M1      = 0b00001000  // Bit 3 (Alt/Meta)
 ModMask::M2      = 0b00010000  // Bit 4 (NumLock)
 ModMask::M3      = 0b00100000  // Bit 5 (ScrollLock)
 ModMask::M4      = 0b01000000  // Bit 6 (Super/Win)
-ModMask::M5      = 0b10000000  // Bit 7 (AltGr)
+ModMask::M5      = 0b10000000  // Bit 7 (ISO_Level3_Shift)
 
 // Combining modifiers uses bitwise OR:
 Ctrl+Alt = ModMask::CONTROL | ModMask::M1 = 0b00001100

--- a/docs/adr/008-x11-modifier-system-and-shortcuts.md
+++ b/docs/adr/008-x11-modifier-system-and-shortcuts.md
@@ -38,10 +38,10 @@ Ctrl+Alt = ModMask::CONTROL | ModMask::M1 = 0b00001100
 ```
 1. Config: "Super+q" = "quit"
    
-2. Parse (KeyParser):
+2. Parse (ShortcutManager):
    "Super+q" → (ModMask::M4, 0x0071)
    
-3. Register (KeyboardManager):
+3. Register (ShortcutManager):
    - Convert: 0x0071 → keycode 24
    - Grab: grab_key(M4, 24)
    - Store: Shortcut { modifiers: M4, keycode: 24, command: "quit" }

--- a/docs/adr/009-unify-keyboard-modules-into-shortcut-manager.md
+++ b/docs/adr/009-unify-keyboard-modules-into-shortcut-manager.md
@@ -1,0 +1,92 @@
+# ADR-009: Unify Keyboard Modules into ShortcutManager
+
+## Status
+Accepted
+
+## Context
+The keyboard module contained two separate structs: `KeyParser` and `KeyboardManager`. Analysis revealed that:
+
+1. **KeyParser was never used independently** - It was only created and owned by KeyboardManager
+2. **Artificial separation** - The split didn't represent a real architectural boundary
+3. **Naming confusion** - "Manager" suffix was vague and didn't express the actual responsibility
+4. **Unnecessary complexity** - Two structs for what is conceptually one responsibility: managing keyboard shortcuts
+
+## Decision
+Combine `KeyParser` and `KeyboardManager` into a single `ShortcutManager` struct that handles the complete lifecycle of keyboard shortcuts from configuration parsing to X11 event handling.
+
+### Before: Two Structs
+```rust
+// Separate parser for config strings
+pub struct KeyParser {
+    keyname_to_keysym: HashMap<String, u32>,
+}
+
+// Manager that owns parser and handles X11
+pub struct KeyboardManager {
+    keycode_map: HashMap<u32, u8>,
+    shortcuts: Vec<Shortcut>,
+    key_parser: KeyParser,  // Owned dependency
+}
+```
+
+### After: One Unified Struct
+```rust
+// Single struct managing shortcuts end-to-end
+pub struct ShortcutManager {
+    keyname_to_keysym: HashMap<String, u32>,   // From KeyParser
+    keysym_to_keycode: HashMap<u32, u8>,       // From KeyboardManager
+    shortcuts: Vec<Shortcut>,                  // From KeyboardManager
+}
+```
+
+### Method Organization
+```rust
+impl ShortcutManager {
+    // Public API
+    pub fn new() -> Result<Self>
+    pub fn register_shortcuts() -> Result<()>
+    pub fn handle_key_press() -> Option<&str>
+    
+    // Private helpers (formerly KeyParser methods)
+    fn parse_key_combination() -> Result<(ModMask, u32)>
+    fn get_keysym() -> Result<u32>
+    fn get_keycode() -> Result<u8>
+}
+```
+
+## Consequences
+
+### Positive
+- **Simpler architecture** - One cohesive unit instead of artificial separation
+- **Clearer naming** - `ShortcutManager` immediately conveys its purpose
+- **Reduced complexity** - No ownership dependencies between structs
+- **Better encapsulation** - Parsing logic is properly private
+- **Easier testing** - Single struct to test without inter-dependencies
+
+### Negative
+- **Larger struct** - Combined struct has more responsibilities
+- **API change** - Breaking change for any external users (none currently)
+
+### Neutral
+- **Line count unchanged** - Same logic, just reorganized
+- **Performance unchanged** - No runtime impact
+
+## Implementation Details
+
+### Migration Steps
+1. Move all `KeyParser` methods into `ShortcutManager` as private methods
+2. Merge data fields from both structs
+3. Update `WindowManager` to use `ShortcutManager`
+4. Update all documentation references
+5. Preserve all existing tests with minimal changes
+
+### Test Strategy
+All existing tests were preserved by:
+- Creating a helper function `create_test_manager()` for test setup
+- Replacing `KeyParser::new()` with the helper function
+- Keeping test logic identical to ensure no regression
+
+## References
+- Original separation was premature abstraction
+- Follows principle: "Make it work, make it right, make it fast"
+- Aligns with Rust's preference for composition when ownership is clear

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -80,7 +80,7 @@ impl KeyParser {
                 // Less common modifiers
                 "mod2" | "numlock" | "num" => modifiers |= ModMask::M2,
                 "mod3" | "scrolllock" | "scroll" => modifiers |= ModMask::M3,
-                "mod5" | "altgr" | "altgraph" => modifiers |= ModMask::M5,
+                "mod5" => modifiers |= ModMask::M5,
 
                 // Special combination: all four main modifiers at once
                 "hyper" => {
@@ -166,7 +166,7 @@ impl KeyboardManager {
 
         // Each physical key can produce multiple symbols
         // Example: keycode 38 → [0x0061 ('a'), 0x0041 ('A'), 0x00e1 ('á'), 0x00c1 ('Á')]
-        // depending on which modifiers (none, Shift, AltGr, Shift+AltGr) are pressed
+        // depending on which modifiers (none, Shift, etc.) are pressed
         let keysyms_per_keycode = mapping_reply.keysyms_per_keycode as usize;
         let mut keycode_map = HashMap::new();
 
@@ -352,14 +352,6 @@ mod tests {
         let (modifiers, keysym) = parser.parse_combination("NumLock+Return").unwrap();
         assert_eq!(modifiers, ModMask::M2);
         assert_eq!(keysym, 0xff0d);
-    }
-
-    #[test]
-    fn test_altgr_modifier() {
-        let parser = KeyParser::new();
-        let (modifiers, keysym) = parser.parse_combination("AltGr+e").unwrap();
-        assert_eq!(modifiers, ModMask::M5);
-        assert_eq!(keysym, 'e' as u32);
     }
 
     #[test]

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,4 +1,4 @@
-//! Keyboard handling, key parsing, and shortcut management
+//! Keyboard shortcut management for X11 window manager
 
 use anyhow::Result;
 use std::collections::HashMap;
@@ -6,18 +6,83 @@ use tracing::{error, info};
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
 
-// ==================== Key Parser ====================
-
-/// Key combination parser that converts keynames to keysyms
-pub struct KeyParser {
-    /// Map of keynames to keysym values
-    /// Example: "q" → 0x0071, "Return" → 0xff0d
-    keyname_to_keysym: HashMap<String, u32>,
+/// Shortcut information
+#[derive(Debug, Clone)]
+pub struct Shortcut {
+    pub modifiers: ModMask, // Bit flags for Ctrl, Alt, etc.
+    pub keycode: u8,        // Physical key position
+    pub command: String,    // Command to execute
 }
 
-impl KeyParser {
-    /// Creates a new key parser with common keyname-to-keysym mappings
-    pub fn new() -> Self {
+/// Manages keyboard shortcuts from configuration to X11 event handling
+pub struct ShortcutManager {
+    /// Map of keynames to keysym values for parsing config
+    /// Example: "q" → 0x0071, "Return" → 0xff0d
+    keyname_to_keysym: HashMap<String, u32>,
+    /// Map of keysym values to keycodes from X11
+    /// Example: 0x0071 ('q') → 24, 0x0061 ('a') → 38
+    keysym_to_keycode: HashMap<u32, u8>,
+    /// Registered shortcuts
+    shortcuts: Vec<Shortcut>,
+}
+
+impl ShortcutManager {
+    /// Creates a new shortcut manager and initializes keysym-to-keycode mapping
+    pub fn new<C: Connection>(conn: &C, setup: &Setup) -> Result<Self> {
+        let min_keycode = setup.min_keycode;
+        let max_keycode = setup.max_keycode;
+
+        // Get keyboard mapping from X server
+        // X11 returns a flat array of keysym numbers (u32 values)
+        // Example: [0x0061, 0x0041, 0x0061, 0x0041, 0x0073, 0x0053, ...]
+        //           ('a')   ('A')   ('a')   ('A')   ('s')   ('S')
+        //           └─────── keycode 38 ────────┘    └── keycode 39 ──┘
+        let mapping_reply = conn
+            .get_keyboard_mapping(min_keycode, max_keycode - min_keycode + 1)?
+            .reply()?;
+
+        // Each physical key can produce multiple symbols
+        // Example: keycode 38 → [0x0061 ('a'), 0x0041 ('A'), 0x00e1 ('á'), 0x00c1 ('Á')]
+        // depending on which modifiers (none, Shift, etc.) are pressed
+        let keysyms_per_keycode = mapping_reply.keysyms_per_keycode as usize;
+        let mut keysym_to_keycode = HashMap::new();
+
+        // Build reverse map: keysym → keycode
+        // This allows us to convert keynames to keycodes
+        // Example flow: "q" → 0x0071 → keycode 24
+        for (index, chunk) in mapping_reply
+            .keysyms
+            .chunks(keysyms_per_keycode)
+            .enumerate()
+        {
+            // Calculate the actual keycode for this chunk
+            let keycode = min_keycode + index as u8;
+
+            // Store only the first keysym (unmodified position) for each keycode
+            // Example: chunk = [0x0061 ('a'), 0x0041 ('A'), 0x00e1 ('á'), 0x00c1 ('Á')]
+            // We store: keysym_to_keycode.insert(0x0061, 38)
+            // This creates mapping: 0x0061 → keycode 38
+            if let Some(&keysym) = chunk.first() {
+                if keysym != 0 {
+                    keysym_to_keycode.insert(keysym, keycode);
+                }
+            }
+        }
+
+        info!(
+            "Initialized shortcut manager with {} keycodes",
+            keysym_to_keycode.len()
+        );
+
+        Ok(Self {
+            keyname_to_keysym: Self::build_keysym_table(),
+            keysym_to_keycode,
+            shortcuts: Vec::new(),
+        })
+    }
+
+    /// Builds the keyname-to-keysym mapping table
+    fn build_keysym_table() -> HashMap<String, u32> {
         let mut keyname_to_keysym = HashMap::new();
 
         // Letters: "a" → 0x0061 (97), "b" → 0x0062 (98), etc.
@@ -52,12 +117,91 @@ impl KeyParser {
             keyname_to_keysym.insert(format!("F{i}"), 0xffbe + i - 1);
         }
 
-        Self { keyname_to_keysym }
+        keyname_to_keysym
+    }
+
+    /// Registers shortcuts from configuration
+    pub fn register_shortcuts<C: Connection>(
+        &mut self,
+        conn: &C,
+        root_window: Window,
+        shortcuts_config: &HashMap<String, String>,
+    ) -> Result<()> {
+        self.shortcuts.clear();
+
+        for (key_combo, command) in shortcuts_config {
+            match self.register_shortcut(conn, root_window, key_combo, command) {
+                Ok(()) => {
+                    info!("Registered shortcut: {} -> {}", key_combo, command);
+                }
+                Err(e) => {
+                    error!("Failed to register shortcut {}: {}", key_combo, e);
+                }
+            }
+        }
+
+        info!("Registered {} shortcuts", self.shortcuts.len());
+        Ok(())
+    }
+
+    /// Registers a single shortcut
+    fn register_shortcut<C: Connection>(
+        &mut self,
+        conn: &C,
+        root_window: Window,
+        key_combo: &str,
+        command: &str,
+    ) -> Result<()> {
+        // Parse key combination string into modifiers and keysym
+        // Example: "Super+q" → (ModMask::M4, 0x0071)
+        let (modifiers, keysym) = self.parse_key_combination(key_combo)?;
+
+        // Convert keysym to keycode using our mapping
+        // Example: 0x0071 ('q') → keycode 24
+        let keycode = self.get_keycode(keysym)?;
+
+        // Tell X11 to send us KeyPress events when this combination is pressed
+        conn.grab_key(
+            true,
+            root_window,
+            modifiers,
+            keycode,
+            GrabMode::ASYNC,
+            GrabMode::ASYNC,
+        )?;
+
+        // Store the shortcut for later lookup when we receive key events
+        self.shortcuts.push(Shortcut {
+            modifiers,
+            keycode,
+            command: command.to_string(),
+        });
+
+        Ok(())
+    }
+
+    /// Handles a key press event and returns the command if a shortcut matches
+    pub fn handle_key_press(&self, event: &KeyPressEvent) -> Option<&str> {
+        // Filter out lock keys (NumLock, CapsLock, ScrollLock) so they don't break shortcuts
+        let relevant_modifiers = ModMask::SHIFT.bits()
+            | ModMask::CONTROL.bits()
+            | ModMask::M1.bits()
+            | ModMask::M4.bits();
+        let event_modifiers_bits = event.state.bits() & relevant_modifiers;
+
+        // Match event against stored shortcuts (both modifiers and keycode must match)
+        for shortcut in &self.shortcuts {
+            if event_modifiers_bits == shortcut.modifiers.bits() && event.detail == shortcut.keycode
+            {
+                return Some(&shortcut.command);
+            }
+        }
+        None
     }
 
     /// Parses a key combination string like "Super+t" or "Ctrl+Alt+Return"
     /// Returns modifiers and the keysym for the key
-    pub fn parse_combination(&self, combo: &str) -> Result<(ModMask, u32)> {
+    fn parse_key_combination(&self, combo: &str) -> Result<(ModMask, u32)> {
         let parts: Vec<&str> = combo.split('+').collect();
 
         if parts.is_empty() {
@@ -107,7 +251,7 @@ impl KeyParser {
     }
 
     /// Gets the keysym for a given keyname
-    pub fn get_keysym(&self, keyname: &str) -> Result<u32> {
+    fn get_keysym(&self, keyname: &str) -> Result<u32> {
         // Try exact match first
         if let Some(&keysym) = self.keyname_to_keysym.get(keyname) {
             return Ok(keysym);
@@ -120,177 +264,15 @@ impl KeyParser {
 
         Err(anyhow::anyhow!("Unknown keyname: {}", keyname))
     }
-}
-
-impl Default for KeyParser {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// ==================== Keyboard Manager ====================
-
-/// Shortcut information
-#[derive(Debug, Clone)]
-pub struct Shortcut {
-    pub modifiers: ModMask, // Bit flags for Ctrl, Alt, etc.
-    pub keycode: u8,        // Physical key position
-    pub command: String,    // Command to execute
-}
-
-/// Manages keysym-to-keycode mapping and shortcuts
-pub struct KeyboardManager {
-    /// Map of keysym values to keycodes from X11
-    /// Example: 0x0071 ('q') → 24, 0x0061 ('a') → 38
-    keycode_map: HashMap<u32, u8>,
-    /// Registered shortcuts
-    shortcuts: Vec<Shortcut>,
-    /// Keyname-to-keysym parser
-    key_parser: KeyParser,
-}
-
-impl KeyboardManager {
-    /// Creates a new keyboard manager and initializes keysym-to-keycode mapping
-    pub fn new<C: Connection>(conn: &C, setup: &Setup) -> Result<Self> {
-        let min_keycode = setup.min_keycode;
-        let max_keycode = setup.max_keycode;
-
-        // Get keyboard mapping from X server
-        // X11 returns a flat array of keysym numbers (u32 values)
-        // Example: [0x0061, 0x0041, 0x0061, 0x0041, 0x0073, 0x0053, ...]
-        //           ('a')   ('A')   ('a')   ('A')   ('s')   ('S')
-        //           └─────── keycode 38 ────────┘    └── keycode 39 ──┘
-        let mapping_reply = conn
-            .get_keyboard_mapping(min_keycode, max_keycode - min_keycode + 1)?
-            .reply()?;
-
-        // Each physical key can produce multiple symbols
-        // Example: keycode 38 → [0x0061 ('a'), 0x0041 ('A'), 0x00e1 ('á'), 0x00c1 ('Á')]
-        // depending on which modifiers (none, Shift, etc.) are pressed
-        let keysyms_per_keycode = mapping_reply.keysyms_per_keycode as usize;
-        let mut keycode_map = HashMap::new();
-
-        // Build reverse map: keysym → keycode
-        // This allows us to convert keynames to keycodes
-        // Example flow: "q" → 0x0071 → keycode 24
-        for (index, chunk) in mapping_reply
-            .keysyms
-            .chunks(keysyms_per_keycode)
-            .enumerate()
-        {
-            // Calculate the actual keycode for this chunk
-            let keycode = min_keycode + index as u8;
-
-            // Store only the first keysym (unmodified position) for each keycode
-            // Example: chunk = [0x0061 ('a'), 0x0041 ('A'), 0x00e1 ('á'), 0x00c1 ('Á')]
-            // We store: keycode_map.insert(0x0061, 38)
-            // This creates mapping: 0x0061 → keycode 38
-            if let Some(&keysym) = chunk.first() {
-                if keysym != 0 {
-                    keycode_map.insert(keysym, keycode);
-                }
-            }
-        }
-
-        info!(
-            "Initialized keyboard manager with {} keycodes",
-            keycode_map.len()
-        );
-
-        Ok(Self {
-            keycode_map,
-            shortcuts: Vec::new(),
-            key_parser: KeyParser::new(),
-        })
-    }
-
-    /// Registers shortcuts from configuration
-    pub fn register_shortcuts<C: Connection>(
-        &mut self,
-        conn: &C,
-        root_window: Window,
-        shortcuts_config: &HashMap<String, String>,
-    ) -> Result<()> {
-        self.shortcuts.clear();
-
-        for (key_combo, command) in shortcuts_config {
-            match self.register_shortcut(conn, root_window, key_combo, command) {
-                Ok(()) => {
-                    info!("Registered shortcut: {} -> {}", key_combo, command);
-                }
-                Err(e) => {
-                    error!("Failed to register shortcut {}: {}", key_combo, e);
-                }
-            }
-        }
-
-        info!("Registered {} shortcuts", self.shortcuts.len());
-        Ok(())
-    }
-
-    /// Registers a single shortcut
-    fn register_shortcut<C: Connection>(
-        &mut self,
-        conn: &C,
-        root_window: Window,
-        key_combo: &str,
-        command: &str,
-    ) -> Result<()> {
-        // Parse key combination string into modifiers and keysym
-        // Example: "Super+q" → (ModMask::M4, 0x0071)
-        let (modifiers, keysym) = self.key_parser.parse_combination(key_combo)?;
-
-        // Convert keysym to keycode using our mapping
-        // Example: 0x0071 ('q') → keycode 24
-        let keycode = self.get_keycode(keysym)?;
-
-        // Tell X11 to send us KeyPress events when this combination is pressed
-        conn.grab_key(
-            true,
-            root_window,
-            modifiers,
-            keycode,
-            GrabMode::ASYNC,
-            GrabMode::ASYNC,
-        )?;
-
-        // Store the shortcut for later lookup when we receive key events
-        self.shortcuts.push(Shortcut {
-            modifiers,
-            keycode,
-            command: command.to_string(),
-        });
-
-        Ok(())
-    }
 
     /// Gets the keycode for a given keysym
     /// Example: get_keycode(0x0071) → 24 (the 'q' key's keycode)
     /// Returns error if keysym not found (e.g., modifier keysyms aren't stored)
     fn get_keycode(&self, keysym: u32) -> Result<u8> {
-        self.keycode_map
+        self.keysym_to_keycode
             .get(&keysym)
             .copied()
             .ok_or_else(|| anyhow::anyhow!("Could not find keycode for keysym: {:#x}", keysym))
-    }
-
-    /// Handles a key press event and returns the command if a shortcut matches
-    pub fn handle_key_press(&self, event: &KeyPressEvent) -> Option<&str> {
-        // Filter out lock keys (NumLock, CapsLock, ScrollLock) so they don't break shortcuts
-        let relevant_modifiers = ModMask::SHIFT.bits()
-            | ModMask::CONTROL.bits()
-            | ModMask::M1.bits()
-            | ModMask::M4.bits();
-        let event_modifiers_bits = event.state.bits() & relevant_modifiers;
-
-        // Match event against stored shortcuts (both modifiers and keycode must match)
-        for shortcut in &self.shortcuts {
-            if event_modifiers_bits == shortcut.modifiers.bits() && event.detail == shortcut.keycode
-            {
-                return Some(&shortcut.command);
-            }
-        }
-        None
     }
 }
 
@@ -298,66 +280,75 @@ impl KeyboardManager {
 mod tests {
     use super::*;
 
-    // ==================== KeyParser Tests ====================
+    // Helper function to create a ShortcutManager for testing
+    fn create_test_manager() -> ShortcutManager {
+        ShortcutManager {
+            keyname_to_keysym: ShortcutManager::build_keysym_table(),
+            keysym_to_keycode: HashMap::new(),
+            shortcuts: Vec::new(),
+        }
+    }
+
+    // ==================== Key Parsing Tests ====================
 
     #[test]
     fn test_parse_simple_key() {
-        let parser = KeyParser::new();
-        let (modifiers, keysym) = parser.parse_combination("t").unwrap();
+        let manager = create_test_manager();
+        let (modifiers, keysym) = manager.parse_key_combination("t").unwrap();
         assert_eq!(modifiers, ModMask::from(0u16));
         assert_eq!(keysym, 't' as u32);
     }
 
     #[test]
     fn test_parse_modified_key() {
-        let parser = KeyParser::new();
-        let (modifiers, keysym) = parser.parse_combination("Super+t").unwrap();
+        let manager = create_test_manager();
+        let (modifiers, keysym) = manager.parse_key_combination("Super+t").unwrap();
         assert_eq!(modifiers, ModMask::M4);
         assert_eq!(keysym, 't' as u32);
     }
 
     #[test]
     fn test_parse_multiple_modifiers() {
-        let parser = KeyParser::new();
-        let (modifiers, keysym) = parser.parse_combination("Ctrl+Alt+Return").unwrap();
+        let manager = create_test_manager();
+        let (modifiers, keysym) = manager.parse_key_combination("Ctrl+Alt+Return").unwrap();
         assert_eq!(modifiers, ModMask::CONTROL | ModMask::M1);
         assert_eq!(keysym, 0xff0d);
     }
 
     #[test]
     fn test_parse_special_key() {
-        let parser = KeyParser::new();
-        let (modifiers, keysym) = parser.parse_combination("F1").unwrap();
+        let manager = create_test_manager();
+        let (modifiers, keysym) = manager.parse_key_combination("F1").unwrap();
         assert_eq!(modifiers, ModMask::from(0u16));
         assert_eq!(keysym, 0xffbe);
     }
 
     #[test]
     fn test_unknown_key() {
-        let parser = KeyParser::new();
-        assert!(parser.parse_combination("unknown_key").is_err());
+        let manager = create_test_manager();
+        assert!(manager.parse_key_combination("unknown_key").is_err());
     }
 
     #[test]
     fn test_mod2_modifier() {
-        let parser = KeyParser::new();
-        let (modifiers, keysym) = parser.parse_combination("Mod2+t").unwrap();
+        let manager = create_test_manager();
+        let (modifiers, keysym) = manager.parse_key_combination("Mod2+t").unwrap();
         assert_eq!(modifiers, ModMask::M2);
         assert_eq!(keysym, 't' as u32);
     }
 
     #[test]
     fn test_numlock_modifier() {
-        let parser = KeyParser::new();
-        let (modifiers, keysym) = parser.parse_combination("NumLock+Return").unwrap();
+        let manager = create_test_manager();
+        let (modifiers, keysym) = manager.parse_key_combination("NumLock+Return").unwrap();
         assert_eq!(modifiers, ModMask::M2);
         assert_eq!(keysym, 0xff0d);
     }
 
     #[test]
     fn test_hyper_modifier() {
-        let parser = KeyParser::new();
-        let (modifiers, keysym) = parser.parse_combination("Hyper+space").unwrap();
+        let manager = create_test_manager();
+        let (modifiers, keysym) = manager.parse_key_combination("Hyper+space").unwrap();
         let expected = ModMask::M4 | ModMask::M1 | ModMask::CONTROL | ModMask::SHIFT;
         assert_eq!(modifiers, expected);
         assert_eq!(keysym, 0x0020);
@@ -365,32 +356,32 @@ mod tests {
 
     #[test]
     fn test_alternative_modifier_names() {
-        let parser = KeyParser::new();
+        let manager = create_test_manager();
 
         // Test cmd as alias for Super
-        let (modifiers1, _) = parser.parse_combination("Cmd+t").unwrap();
-        let (modifiers2, _) = parser.parse_combination("Super+t").unwrap();
+        let (modifiers1, _) = manager.parse_key_combination("Cmd+t").unwrap();
+        let (modifiers2, _) = manager.parse_key_combination("Super+t").unwrap();
         assert_eq!(modifiers1, modifiers2);
 
         // Test meta as alias for Alt
-        let (modifiers1, _) = parser.parse_combination("Meta+t").unwrap();
-        let (modifiers2, _) = parser.parse_combination("Alt+t").unwrap();
+        let (modifiers1, _) = manager.parse_key_combination("Meta+t").unwrap();
+        let (modifiers2, _) = manager.parse_key_combination("Alt+t").unwrap();
         assert_eq!(modifiers1, modifiers2);
 
         // Test ctl as alias for Ctrl
-        let (modifiers1, _) = parser.parse_combination("Ctl+t").unwrap();
-        let (modifiers2, _) = parser.parse_combination("Ctrl+t").unwrap();
+        let (modifiers1, _) = manager.parse_key_combination("Ctl+t").unwrap();
+        let (modifiers2, _) = manager.parse_key_combination("Ctrl+t").unwrap();
         assert_eq!(modifiers1, modifiers2);
     }
 
     #[test]
     fn test_left_right_modifiers() {
-        let parser = KeyParser::new();
+        let manager = create_test_manager();
 
         // Left and right should map to same modifier
-        let (mod_l, _) = parser.parse_combination("Super_L+t").unwrap();
-        let (mod_r, _) = parser.parse_combination("Super_R+t").unwrap();
-        let (mod_normal, _) = parser.parse_combination("Super+t").unwrap();
+        let (mod_l, _) = manager.parse_key_combination("Super_L+t").unwrap();
+        let (mod_r, _) = manager.parse_key_combination("Super_R+t").unwrap();
+        let (mod_normal, _) = manager.parse_key_combination("Super+t").unwrap();
 
         assert_eq!(mod_l, ModMask::M4);
         assert_eq!(mod_r, ModMask::M4);
@@ -399,17 +390,19 @@ mod tests {
 
     #[test]
     fn test_complex_modifier_combinations() {
-        let parser = KeyParser::new();
+        let manager = create_test_manager();
 
         // Test triple modifier
-        let (modifiers, keysym) = parser.parse_combination("Ctrl+Alt+Shift+Delete").unwrap();
+        let (modifiers, keysym) = manager
+            .parse_key_combination("Ctrl+Alt+Shift+Delete")
+            .unwrap();
         let expected = ModMask::CONTROL | ModMask::M1 | ModMask::SHIFT;
         assert_eq!(modifiers, expected);
         assert_eq!(keysym, 0xffff); // Delete key
 
         // Test quadruple modifier
-        let (modifiers, keysym) = parser
-            .parse_combination("Super+Ctrl+Alt+Shift+F12")
+        let (modifiers, keysym) = manager
+            .parse_key_combination("Super+Ctrl+Alt+Shift+F12")
             .unwrap();
         let expected = ModMask::M4 | ModMask::CONTROL | ModMask::M1 | ModMask::SHIFT;
         assert_eq!(modifiers, expected);
@@ -418,12 +411,12 @@ mod tests {
 
     #[test]
     fn test_case_insensitive_modifiers() {
-        let parser = KeyParser::new();
+        let manager = create_test_manager();
 
-        let (mod1, _) = parser.parse_combination("SUPER+t").unwrap();
-        let (mod2, _) = parser.parse_combination("super+t").unwrap();
-        let (mod3, _) = parser.parse_combination("Super+t").unwrap();
-        let (mod4, _) = parser.parse_combination("SuPeR+t").unwrap();
+        let (mod1, _) = manager.parse_key_combination("SUPER+t").unwrap();
+        let (mod2, _) = manager.parse_key_combination("super+t").unwrap();
+        let (mod3, _) = manager.parse_key_combination("Super+t").unwrap();
+        let (mod4, _) = manager.parse_key_combination("SuPeR+t").unwrap();
 
         assert_eq!(mod1, ModMask::M4);
         assert_eq!(mod2, ModMask::M4);
@@ -431,7 +424,7 @@ mod tests {
         assert_eq!(mod4, ModMask::M4);
     }
 
-    // ==================== KeyboardManager Tests ====================
+    // ==================== Shortcut Management Tests ====================
 
     #[test]
     fn test_shortcut_creation() {
@@ -454,10 +447,10 @@ mod tests {
             command: "xterm".to_string(),
         }];
 
-        let km = KeyboardManager {
-            keycode_map: HashMap::new(),
+        let manager = ShortcutManager {
+            keyname_to_keysym: HashMap::new(),
+            keysym_to_keycode: HashMap::new(),
             shortcuts,
-            key_parser: KeyParser::new(),
         };
 
         // Create a mock key press event
@@ -477,7 +470,7 @@ mod tests {
             same_screen: true,
         };
 
-        assert_eq!(km.handle_key_press(&event), Some("xterm"));
+        assert_eq!(manager.handle_key_press(&event), Some("xterm"));
 
         // Test non-matching event
         let event2 = KeyPressEvent {
@@ -486,6 +479,6 @@ mod tests {
             ..event
         };
 
-        assert_eq!(km.handle_key_press(&event2), None);
+        assert_eq!(manager.handle_key_press(&event2), None);
     }
 }


### PR DESCRIPTION
## Summary
- Remove unused AltGr functionality that doesn't exist on US keyboards
- Unify KeyParser and KeyboardManager into a single ShortcutManager struct
- Improve naming and architecture clarity

## Changes

### 1. AltGr Removal
- Removed `altgr` and `altgraph` parsing from keyboard module
- Removed `test_altgr_modifier()` test
- Updated documentation to remove AltGr references
- Cleaned up config examples

### 2. Module Unification
- Combined `KeyParser` and `KeyboardManager` into `ShortcutManager`
- Moved parsing logic as private methods where it belongs
- Eliminated unnecessary ownership dependencies
- Better encapsulation and clearer naming

## Benefits
- **Simpler codebase**: Removed unused functionality and artificial separation
- **Clearer architecture**: One cohesive struct instead of two artificially separated ones
- **Better naming**: `ShortcutManager` immediately conveys its purpose
- **Reduced complexity**: No inter-struct dependencies

## Test Plan
- [x] All 65 unit tests pass
- [x] Code formatting verified with `cargo fmt`
- [x] No clippy warnings with `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Documentation builds successfully
- [ ] Manual testing with Xephyr confirms shortcuts work as expected

## Architecture Decision Records
- Added ADR-009 documenting the module unification decision

🤖 Generated with [Claude Code](https://claude.ai/code)