### PR TITLE
feat: implement zoom to parent feature

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -53,3 +53,4 @@ unfocused_border_color = 0x808080 # Gray color for unfocused windows (hex format
 "Shift+Alt+q" = "destroy_window"    # Close/destroy focused window
 "Alt+f" = "toggle_fullscreen"       # Toggle fullscreen for focused window
 "Alt+r" = "rotate_windows"          # Rotate focused window's parent split direction
+"Alt+d" = "toggle_zoom"             # Toggle zoom to parent for focused window

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ Rustile currently provides:
   - Standardized logging with debug support
 
 - ⭐⭐⭐ **Window Operations**
-  - [ ] **Zoom to parent** - Focus and expand window to its parent container size
+  - [x] **Zoom to parent** - Focus and expand window to its parent container size *(v0.8.0)*
   - [ ] **Auto-balance** - Automatically balance BSP tree ratios for optimal space usage
   - [ ] **Directional insertion** - Insert new windows in specific directions (left/right/up/down)
 
@@ -54,6 +54,11 @@ Rustile currently provides:
   - [ ] **Screenshot utility** - Quick screenshot functionality
   - [ ] **Status bar support** - Integration with external status bars
   - [ ] **Mouse support** - Optional mouse interactions for window management
+
+- **Architecture & Refactoring**
+  - [ ] **Screen rect calculation cleanup** - Move rendering calculations out of BSP tree module
+  - [ ] **Responsibility separation** - Ensure BSP tree focuses purely on tree operations
+  - [ ] **Code duplication elimination** - Remove duplicated screen rectangle calculations
 
 - **Wayland Support**
   - [ ] **Research wlroots** - Investigate Wayland compositor integration

--- a/docs/adr/010-zoom-to-parent-feature.md
+++ b/docs/adr/010-zoom-to-parent-feature.md
@@ -1,7 +1,7 @@
 # ADR-010: Zoom to Parent Feature Implementation
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 Users need to temporarily focus on a specific window without losing the underlying BSP layout structure. The "zoom to parent" feature allows expanding a window to fill its parent container's space, similar to features in other tiling window managers (i3's "fullscreen mode 2", dwm's "zoom", bspwm's "monocle" mode).
@@ -15,7 +15,7 @@ Key design questions:
 ## Decision
 Implement a simple, predictable zoom feature with these characteristics:
 - **Single zoom only**: One window zoomed at a time for simplicity
-- **Toggle interface**: Same key (e.g., Alt+z) to zoom/unzoom
+- **Toggle interface**: Same key (Alt+d) to zoom/unzoom
 - **Overlay rendering**: Use X11 stacking order (z-order) to display zoomed window on top
 - **Non-destructive**: BSP tree structure remains unchanged
 
@@ -30,8 +30,9 @@ Implement a simple, predictable zoom feature with these characteristics:
 - `rotate` command execution (tree structure changes)
 - New window added (user needs to see new window)
 - Zoomed window removed
-- Fullscreen mode activated
-- Screen size changed (XRandR)
+
+#### Events that Prevent Zoom
+- Fullscreen mode active (zoom command ignored while in fullscreen)
 
 #### Events that Preserve Zoom
 - `focus_next`/`focus_prev` commands
@@ -77,7 +78,7 @@ fn clear_zoom(&mut self) -> Result<()>
 ### BSP Tree Enhancement
 ```rust
 // Find parent split bounds for a window
-fn find_parent_bounds(&self, window: Window) -> Option<BspRect>
+fn find_parent_bounds(&self, window: Window, screen_rect: BspRect) -> Option<BspRect>
 ```
 
 ### Rendering Logic

--- a/docs/adr/010-zoom-to-parent-feature.md
+++ b/docs/adr/010-zoom-to-parent-feature.md
@@ -1,0 +1,105 @@
+# ADR-010: Zoom to Parent Feature Implementation
+
+## Status
+Proposed
+
+## Context
+Users need to temporarily focus on a specific window without losing the underlying BSP layout structure. The "zoom to parent" feature allows expanding a window to fill its parent container's space, similar to features in other tiling window managers (i3's "fullscreen mode 2", dwm's "zoom", bspwm's "monocle" mode).
+
+Key design questions:
+1. Allow multiple simultaneous zoomed windows or single zoom only?
+2. How should zoom interact with other operations (focus, rotate, window add/remove)?
+3. Rendering approach: hide siblings or overlay the zoomed window?
+4. User interface: toggle or separate zoom/unzoom commands?
+
+## Decision
+Implement a simple, predictable zoom feature with these characteristics:
+- **Single zoom only**: One window zoomed at a time for simplicity
+- **Toggle interface**: Same key (e.g., Alt+z) to zoom/unzoom
+- **Overlay rendering**: Use X11 stacking order (z-order) to display zoomed window on top
+- **Non-destructive**: BSP tree structure remains unchanged
+
+### Behavior Rules
+
+#### Zoom Toggle Logic
+- No zoom active + focus on window → Zoom focused window to parent bounds
+- Zoom active on focused window → Unzoom
+- Zoom active on different window → Unzoom old, zoom new
+
+#### Events that Clear Zoom
+- `rotate` command execution (tree structure changes)
+- New window added (user needs to see new window)
+- Zoomed window removed
+- Fullscreen mode activated
+- Screen size changed (XRandR)
+
+#### Events that Preserve Zoom
+- `focus_next`/`focus_prev` commands
+- Mouse focus changes
+- Other windows removed (not the zoomed one)
+
+### Examples
+```
+Initial 4-window layout:
+┌─────┬─────────┐
+│     │    B    │
+│  A  ├────┬────┤
+│     │ C  │ D  │
+└─────┴────┴────┘
+
+Zoom C → Fills bottom-right quarter (C+D's parent area):
+┌─────┬─────────┐
+│     │    B    │
+│  A  ├─────────┤
+│     │    C    │
+└─────┴─────────┘
+
+Zoom B → Fills right half (B+CD's parent area):
+┌─────┬─────────┐
+│     │         │
+│  A  │    B    │
+│     │         │
+└─────┴─────────┘
+```
+
+## Implementation Approach
+
+### State Management
+```rust
+// In WindowState
+zoomed_window: Option<Window>
+
+// In WindowRenderer or WindowManager
+fn toggle_zoom(&mut self) -> Result<()>
+fn clear_zoom(&mut self) -> Result<()>
+```
+
+### BSP Tree Enhancement
+```rust
+// Find parent split bounds for a window
+fn find_parent_bounds(&self, window: Window) -> Option<BspRect>
+```
+
+### Rendering Logic
+1. Calculate normal geometries for all windows
+2. If zoom active, override zoomed window's geometry with parent bounds
+3. Configure zoomed window with higher stack order (ConfigureWindowAux::new().stack_mode(StackMode::Above))
+
+## Consequences
+
+### Positive
+- Simple mental model (one zoom at a time)
+- Predictable toggle behavior
+- Non-destructive to layout structure
+- Minimal state management complexity
+- Natural interaction with focus commands
+
+### Negative
+- Cannot zoom multiple windows simultaneously
+- Rotate command breaks zoom (intentional for v1.0 simplicity)
+- Single window (root) cannot zoom (no parent exists)
+
+### Neutral
+- Zoom state is transient (lost on WM restart)
+- Requires BSP tree traversal to find parent bounds
+- Different from fullscreen (window-level vs container-level)

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -401,7 +401,11 @@ impl BspTree {
     }
 
     /// Find the bounds of the parent split containing the target window
-    pub fn find_parent_bounds(&self, target_window: Window, screen_rect: BspRect) -> Option<BspRect> {
+    pub fn find_parent_bounds(
+        &self,
+        target_window: Window,
+        screen_rect: BspRect,
+    ) -> Option<BspRect> {
         if let Some(ref root) = self.root {
             Self::find_parent_bounds_recursive(root, target_window, screen_rect)
         } else {
@@ -424,16 +428,21 @@ impl BspTree {
                     None
                 }
             }
-            BspNode::Split { direction, ratio, left, right } => {
+            BspNode::Split {
+                direction,
+                ratio,
+                left,
+                right,
+            } => {
                 // Check if either child directly contains the target window
                 let left_is_target = matches!(**left, BspNode::Leaf(w) if w == target_window);
                 let right_is_target = matches!(**right, BspNode::Leaf(w) if w == target_window);
-                
+
                 if left_is_target || right_is_target {
                     // This split is the parent of the target window
                     return Some(rect);
                 }
-                
+
                 // Calculate child rectangles and recurse
                 let (left_rect, right_rect) = match direction {
                     SplitDirection::Horizontal => {
@@ -471,7 +480,7 @@ impl BspTree {
                         )
                     }
                 };
-                
+
                 // Try to find in left subtree
                 if Self::contains_window_static(left, target_window) {
                     Self::find_parent_bounds_recursive(left, target_window, left_rect)
@@ -899,13 +908,13 @@ mod tests {
         //          /        \
         //         20        30
         bsp_tree.add_window(30, Some(20), 0.5);
-        
+
         // Window 10's parent is still the root
         assert_eq!(
             bsp_tree.find_parent_bounds(10, screen_rect),
             Some(screen_rect)
         );
-        
+
         // Windows 20 and 30's parent should be the right half (vertical split)
         let right_half = BspRect {
             x: 500,

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -112,6 +112,7 @@ impl<C: Connection> WindowManager<C> {
                 "destroy_window" => return self.destroy_focused_window(),
                 "toggle_fullscreen" => return self.toggle_fullscreen(),
                 "rotate_windows" => return self.rotate_windows(),
+                "toggle_zoom" => return self.toggle_zoom(),
                 _ => {
                     let parts: Vec<&str> = command.split_whitespace().collect();
                     if let Some(program) = parts.first() {
@@ -290,6 +291,12 @@ impl<C: Connection> WindowManager<C> {
     pub fn rotate_windows(&mut self) -> Result<()> {
         self.window_renderer
             .rotate_windows(&mut self.conn, &mut self.window_state)
+    }
+
+    /// Toggles zoom for the focused window
+    pub fn toggle_zoom(&mut self) -> Result<()> {
+        self.window_renderer
+            .toggle_zoom(&mut self.conn, &mut self.window_state)
     }
 }
 

--- a/src/window_renderer.rs
+++ b/src/window_renderer.rs
@@ -148,14 +148,23 @@ impl WindowRenderer {
             };
 
             // Find parent bounds for the zoomed window
-            if let Some(parent_bounds) = state.bsp_tree().find_parent_bounds(zoomed_window, screen_rect) {
+            if let Some(parent_bounds) = state
+                .bsp_tree()
+                .find_parent_bounds(zoomed_window, screen_rect)
+            {
                 // Override the zoomed window's geometry with parent bounds
                 for geometry in &mut geometries {
                     if geometry.window == zoomed_window {
                         geometry.x = parent_bounds.x;
                         geometry.y = parent_bounds.y;
-                        geometry.width = parent_bounds.width.max(state.layout_params().min_window_width as i32) as u32;
-                        geometry.height = parent_bounds.height.max(state.layout_params().min_window_height as i32) as u32;
+                        geometry.width = parent_bounds
+                            .width
+                            .max(state.layout_params().min_window_width as i32)
+                            as u32;
+                        geometry.height = parent_bounds
+                            .height
+                            .max(state.layout_params().min_window_height as i32)
+                            as u32;
                         break;
                     }
                 }
@@ -331,7 +340,11 @@ impl WindowRenderer {
             info!("Unzoomed window: {:?}", focused);
         } else {
             // Check if this window can be zoomed (has a parent)
-            if state.bsp_tree().find_parent_bounds(focused, screen_rect).is_none() {
+            if state
+                .bsp_tree()
+                .find_parent_bounds(focused, screen_rect)
+                .is_none()
+            {
                 // Single window or root - cannot zoom
                 info!("Window {:?} has no parent to zoom to", focused);
                 return Ok(());

--- a/src/window_state.rs
+++ b/src/window_state.rs
@@ -81,11 +81,6 @@ impl WindowState {
         self.zoomed_window = None;
     }
 
-    /// Checks if a specific window is zoomed
-    pub fn is_window_zoomed(&self, window: Window) -> bool {
-        self.zoomed_window == Some(window)
-    }
-
     /// Gets all windows currently managed by the layout
     pub fn get_all_windows(&self) -> Vec<Window> {
         self.bsp_tree.all_windows()

--- a/src/window_state.rs
+++ b/src/window_state.rs
@@ -11,6 +11,7 @@ pub struct WindowState {
     focused_window: Option<Window>,
     bsp_tree: BspTree,
     fullscreen_window: Option<Window>,
+    zoomed_window: Option<Window>,
     intentionally_unmapped: HashSet<Window>,
     config: Config,
     screen_num: usize,
@@ -23,6 +24,7 @@ impl WindowState {
             focused_window: None,
             bsp_tree: BspTree::new(),
             fullscreen_window: None,
+            zoomed_window: None,
             intentionally_unmapped: HashSet::new(),
             config,
             screen_num,
@@ -62,6 +64,26 @@ impl WindowState {
     /// Checks if we're in fullscreen mode
     pub fn is_in_fullscreen_mode(&self) -> bool {
         self.fullscreen_window.is_some()
+    }
+
+    /// Gets the current zoomed window
+    pub fn get_zoomed_window(&self) -> Option<Window> {
+        self.zoomed_window
+    }
+
+    /// Sets the zoomed window
+    pub fn set_zoomed_window(&mut self, window: Option<Window>) {
+        self.zoomed_window = window;
+    }
+
+    /// Clears zoom state
+    pub fn clear_zoom(&mut self) {
+        self.zoomed_window = None;
+    }
+
+    /// Checks if a specific window is zoomed
+    pub fn is_window_zoomed(&self, window: Window) -> bool {
+        self.zoomed_window == Some(window)
     }
 
     /// Gets all windows currently managed by the layout
@@ -111,12 +133,18 @@ impl WindowState {
 
     /// Adds a window to the layout manager
     pub fn add_window_to_layout(&mut self, window: Window) {
+        // Clear zoom when adding new window (as per ADR-010)
+        self.clear_zoom();
         self.bsp_tree
             .add_window(window, self.focused_window, self.config.bsp_split_ratio());
     }
 
     /// Removes a window from the layout manager
     pub fn remove_window_from_layout(&mut self, window: Window) {
+        // Clear zoom if removing the zoomed window
+        if self.zoomed_window == Some(window) {
+            self.clear_zoom();
+        }
         self.bsp_tree.remove_window(window);
     }
 
@@ -127,6 +155,8 @@ impl WindowState {
 
     /// Rotates a window in the BSP tree
     pub fn rotate_window(&mut self, window: Window) -> bool {
+        // Clear zoom when rotating (as per ADR-010)
+        self.clear_zoom();
         self.bsp_tree.rotate_window(window)
     }
 
@@ -143,6 +173,11 @@ impl WindowState {
     /// Gets the screen number
     pub fn screen_num(&self) -> usize {
         self.screen_num
+    }
+
+    /// Gets a reference to the BSP tree
+    pub fn bsp_tree(&self) -> &BspTree {
+        &self.bsp_tree
     }
 
     /// Creates layout parameters bundle from config - helper to reduce parameter duplication


### PR DESCRIPTION
## Summary
- Add zoom functionality that allows users to temporarily expand a window to fill its parent container's space
- Non-destructive to BSP tree structure - only affects rendering
- Alt+d keyboard shortcut for toggle zoom operation

## Key Features
- **Single window zoom**: One window zoomed at a time for simplicity
- **Toggle interface**: Alt+d to zoom/unzoom focused window
- **Overlay rendering**: Uses X11 stacking order for visual layering
- **Smart interactions**: Automatic zoom clearing on layout changes

## Implementation Details
- `BspTree::find_parent_bounds()` - Calculate parent container bounds with comprehensive tests
- `WindowState::zoomed_window` - State management for current zoom
- Modified rendering pipeline to override zoomed window geometry
- Proper event handling for zoom clearing (rotate, window add/remove)

## Test Coverage
- ✅ Parent bounds calculation tests
- ✅ All existing tests pass (66 tests)
- ✅ Zero warnings/clippy errors

## Test Plan
- [x] Alt+d zooms focused window to parent area
- [x] Alt+d on zoomed window unzooms
- [x] Single window cannot zoom (no parent)
- [x] Zoom clears on rotate/window changes
- [x] Fullscreen mode prevents zoom
- [x] Focus navigation preserves zoom

🤖 Generated with [Claude Code](https://claude.ai/code)