### PR TITLE
fix: change default_display from :10 to :0

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,7 @@
 
 [general]
 # Default display for launching applications
-default_display = ":10"
+default_display = ":0"
 
 [layout]
 # BSP (Binary Space Partitioning) layout settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,7 +159,7 @@ impl Default for LayoutConfig {
 impl Default for GeneralConfig {
     fn default() -> Self {
         Self {
-            default_display: ":10".to_string(),
+            default_display: ":0".to_string(),
         }
     }
 }
@@ -431,7 +431,7 @@ mod tests {
     #[test]
     fn test_config_accessors() {
         let config = Config::default();
-        assert_eq!(config.default_display(), ":10");
+        assert_eq!(config.default_display(), ":0");
         assert_eq!(config.gap(), 0);
         assert_eq!(config.border_width(), 2);
         assert_eq!(config.focused_border_color(), 0xFF0000);

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,8 @@ pkill -f "rustile.*:10" 2>/dev/null
 echo "Setting up config..."
 mkdir -p ~/.config/rustile
 cp config.example.toml ~/.config/rustile/config.toml
+# Update display setting for test environment
+sed -i 's/default_display = ":0"/default_display = ":10"/' ~/.config/rustile/config.toml
 
 # Build rustile (debug mode for better logging with cfg(debug_assertions))
 echo "Building rustile..."


### PR DESCRIPTION
## Summary
- Update default_display configuration from `:10` to `:0` for better out-of-box experience

## Changes Made
- **config.example.toml**: Changed default_display value from `:10` to `:0`
- **src/config.rs**: Updated default value in GeneralConfig::default()

## Rationale
- `:0` is the standard X11 display for most desktop environments
- `:10` was specific to development/testing with Xephyr 
- Improves user experience for standard installations
- Aligns with conventional X11 usage patterns

## Test plan
- [x] Verify config parsing works with `:0` value
- [x] Confirm example config reflects new default
- [x] Test that existing users with custom config.toml are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)